### PR TITLE
Remove link to page for becoming a post-migration validator in migration validator instructions

### DIFF
--- a/build/set-up-your-own-node/becoming-a-validator.md
+++ b/build/set-up-your-own-node/becoming-a-validator.md
@@ -155,7 +155,7 @@ arpl repl -u ws://<host>:<port>/ws
 # -u is short for --url
 
 # With default settings:
-arpl repl -u ws://locahost:8648/ws
+arpl repl -u ws://localhost:8648/ws
 
 # You can also use other ways of specifying the connection parameters:
 arpl repl -h localhost -p 8648

--- a/migration/validator-activation.md
+++ b/migration/validator-activation.md
@@ -2,8 +2,6 @@
 
 This guide is part of the Nimiq PoW to PoS migration process and is intended for users who have already registered as validators during the Validator Registration Phase by **October 6th, 2024**. If you missed the registration deadline, you can still participate in the activation as an observer by following [this guide](node-operators).
 
-For registering a validator post-transition, refer to the [Becoming a Validator](/build/set-up-your-own-node/becoming-a-validator.md) guide. For more technical details on the migration, see [Migration Technical Details](migration-technical-details).
-
 ## Validator Activation Tool
 
 This guide covers **Phase 3: Validator Activation**, which starts on **November 19th**. The Validator Activation Tool facilitates the transition from the PoW chain to the PoS chain. We recommend running the tool before the activation window begins to allow time for database synchronization, as this process can take some time.

--- a/migration/validator-registration.md
+++ b/migration/validator-registration.md
@@ -1,6 +1,6 @@
 # Registration Guide
 
-This document guides users through the registration process to become one of the first validators on the Nimiq PoS chain. It is part of the overall documentation for the transition from PoW to PoS. For registering a validator post-transition, refer to the [Becoming a Validator](/build/set-up-your-own-node/becoming-a-validator.md) guide. For more technical details on the migration, see [Migration Technical Details](migration-technical-details).
+This document guides users through the registration process to become one of the first validators on the Nimiq PoS chain. It is part of the overall documentation for the transition from PoW to PoS. For more technical details on the migration, see [Migration Technical Details](migration-technical-details).
 
 ## Validator Registration Tool
 


### PR DESCRIPTION
Turns out it is major source of confusion and people use the `Becoming a validator guide` for becoming a migration validator