### PR TITLE
fix sidebar expanding full-width between 1224-1280px

### DIFF
--- a/.vitepress/theme/main.css
+++ b/.vitepress/theme/main.css
@@ -1,9 +1,3 @@
-@media (max-width: 1279px) {
-  [data-layout="docs"][var\:nq-sidebar-width\:100vw] {
-    --nq-sidebar-width: min(100vw, 100%);
-  }
-}
-
 div:has(+ article) {
   margin: 0 auto;
   gap: 16px;


### PR DESCRIPTION
CSS override in main.css had higher specificity than the UnoCSS `md:288px` rule, making sidebar 100vw while in desktop mode. Mobile layout doesn't use this variable, so the override was unnecessary.