### PR TITLE
Mini apps/skill fixes 181 184

### DIFF
--- a/content/mini-apps/load-local-mini-app.md
+++ b/content/mini-apps/load-local-mini-app.md
@@ -41,6 +41,27 @@ npm run dev -- --host
 
 Note the **Network** URL in the terminal output, for example `http://192.168.1.42:5173`.
 
+::callout{color="info" title="HMR over LAN with Docker"}
+
+If you're running the Vite dev server inside Docker, hot module reload (HMR) may fail silently when the app is opened on your phone. The HMR client tries to connect through container-internal addresses the phone cannot reach.
+
+To fix it, set `VITE_HMR_HOST` to your host machine's LAN IP and add an `hmr` block to your `vite.config`:
+
+```ts
+const hmrHost = process.env.VITE_HMR_HOST
+
+export default defineConfig({
+  server: {
+    host: true,
+    port: 5173,
+    hmr: hmrHost ? { host: hmrHost, protocol: 'ws', clientPort: 5173 } : undefined,
+  },
+})
+```
+
+Then run with the env variable set: `VITE_HMR_HOST=<your-LAN-IP> npm run dev -- --host`. Outside Docker, the default Vite config works without this.
+::
+
 ## Open your local app in Nimiq Pay
 
 1. Open **Nimiq Pay** on your phone.

--- a/skills/mini-apps/references/scaffold.md
+++ b/skills/mini-apps/references/scaffold.md
@@ -38,6 +38,8 @@ If the app uses the Nimiq provider (most apps will):
 npm install @nimiq/mini-app-sdk
 ```
 
+If the developer encounters unexpected behaviour, check the [SDK release notes](https://www.npmjs.com/package/@nimiq/mini-app-sdk) for recent breaking changes.
+
 If the app only uses the Ethereum provider, no SDK is needed. `window.ethereum` is injected by Nimiq Pay.
 
 If the app needs ABI encoding for ERC-20 token interaction, also install an EVM library:


### PR DESCRIPTION
closes #181 and #184 

- 181: Added a pointer to the SDK's npm page so the agent knows where to check if something looks outdated. Pinning the version would just create maintenance work for no real benefit, since the SDK isn't churning fast enough to need it.
- 184: Added a callout for the HMR issue, scoped to Docker. I reproduced it without Docker and HMR worked fine out of the box, so the problem is too specific to justify changing the Vite config everywhere the dev server is documented.