### PR TITLE
mini-apps: restructure hub sidebar into tutorials, development, and features

### DIFF
--- a/app/components/docs/DocsAsideLeftBody.vue
+++ b/app/components/docs/DocsAsideLeftBody.vue
@@ -62,14 +62,10 @@ const protocolNavigationRank = new Map<string, number>(
 
 const miniAppsNavigationOrder = [
   '',
-  'mini-app-tutorial',
-  'dual-chain-mini-app-tutorial',
-  'load-local-mini-app',
-  'build-with-ai',
   'ideas',
-  'evm-tokens',
-  'localization',
-  'device-identifier',
+  'tutorials',
+  'development',
+  'features',
   'api-reference',
   'faq',
 ] as const
@@ -78,15 +74,15 @@ const miniAppsNavigationRank = new Map<string, number>(
   miniAppsNavigationOrder.map((segment, index) => [segment, index]),
 )
 
-const apiReferenceChildOrder = [
-  '',
-  'nimiq-provider',
-  'ethereum-provider',
-] as const
-
-const apiReferenceChildRank = new Map<string, number>(
-  apiReferenceChildOrder.map((segment, index) => [segment, index]),
-)
+// Within-folder order for mini-apps sections, keyed by folder segment then leaf
+// slug. Nuxt Content sorts children alphabetically by default, so each folder
+// whose order matters is listed explicitly here ('' is the folder's index page).
+const miniAppsChildOrder: Record<string, readonly string[]> = {
+  'tutorials': ['mini-app-tutorial', 'dual-chain-mini-app-tutorial'],
+  'development': ['load-local-mini-app', 'build-with-ai'],
+  'features': ['evm-tokens', 'localization', 'device-identifier'],
+  'api-reference': ['', 'nimiq-provider', 'ethereum-provider'],
+}
 
 const sidebarNavigation = computed<SidebarNavigationItem[]>(() => {
   if (!isRpcMethodsPage.value) {
@@ -179,19 +175,21 @@ function sortMiniAppsNavigation(items: SidebarNavigationItem[]) {
       return (a.title || '').localeCompare(b.title || '')
     })
     .map((item) => {
-      if (getMiniAppsSegment(item) === 'api-reference' && item.children?.length) {
-        return { ...item, children: sortApiReferenceChildren(item.children) }
+      const segment = getMiniAppsSegment(item)
+      if (segment && item.children?.length && miniAppsChildOrder[segment]) {
+        return { ...item, children: sortMiniAppsChildren(item.children, segment) }
       }
       return item
     })
 }
 
-function sortApiReferenceChildren(items: SidebarNavigationItem[]) {
+function sortMiniAppsChildren(items: SidebarNavigationItem[], parentSegment: string) {
+  const order = miniAppsChildOrder[parentSegment] ?? []
+  const rank = new Map<string, number>(order.map((segment, index) => [segment, index]))
+
   return [...items].sort((a, b) => {
-    const segA = getApiReferenceChildSegment(a)
-    const segB = getApiReferenceChildSegment(b)
-    const rankA = apiReferenceChildRank.get(segA) ?? Number.MAX_SAFE_INTEGER
-    const rankB = apiReferenceChildRank.get(segB) ?? Number.MAX_SAFE_INTEGER
+    const rankA = rank.get(getMiniAppsChildSegment(a)) ?? Number.MAX_SAFE_INTEGER
+    const rankB = rank.get(getMiniAppsChildSegment(b)) ?? Number.MAX_SAFE_INTEGER
 
     if (rankA !== rankB) {
       return rankA - rankB
@@ -222,7 +220,7 @@ function getMiniAppsNavigationRank(item: SidebarNavigationItem) {
   return miniAppsNavigationRank.get(segment) ?? Number.MAX_SAFE_INTEGER
 }
 
-function getApiReferenceChildSegment(item: SidebarNavigationItem) {
+function getMiniAppsChildSegment(item: SidebarNavigationItem) {
   const candidatePath = item.path || ''
   const segments = normalizePath(candidatePath).split('/').filter(Boolean)
   return segments[2] || ''

--- a/content/mini-apps/api-reference/_dir.yml
+++ b/content/mini-apps/api-reference/_dir.yml
@@ -1,3 +1,3 @@
 title: API Reference
 icon: i-tabler-api
-navigation.order: 9
+navigation.order: 6

--- a/content/mini-apps/api-reference/ethereum-provider.md
+++ b/content/mini-apps/api-reference/ethereum-provider.md
@@ -520,7 +520,7 @@ Returns the current network id.
 const networkId = await provider.request({ method: 'net_version' })
 ```
 
-For a practical guide to reading ERC-20 token balances and sending token transfers through this provider, see [Using EVM Tokens in Mini Apps](/mini-apps/evm-tokens).
+For a practical guide to reading ERC-20 token balances and sending token transfers through this provider, see [Using EVM Tokens in Mini Apps](/mini-apps/features/evm-tokens).
 
 ## EIP-6963 Provider Discovery
 

--- a/content/mini-apps/api-reference/index.md
+++ b/content/mini-apps/api-reference/index.md
@@ -15,7 +15,7 @@ This API is injected by the host app into the mini app environment. For Nimiq ac
 - [Nimiq provider](/mini-apps/api-reference/nimiq-provider)
 - [Ethereum provider](/mini-apps/api-reference/ethereum-provider)
 
-To load and build a mini app, see [Load a Local Mini App in Nimiq Pay](/mini-apps/load-local-mini-app), the [Mini app tutorial](/mini-apps/mini-app-tutorial), and [Build a Dual-Chain Mini App with Nimiq Pay](/mini-apps/dual-chain-mini-app-tutorial).
+To load and build a mini app, see [Load a Local Mini App in Nimiq Pay](/mini-apps/development/load-local-mini-app), the [Mini app tutorial](/mini-apps/tutorials/mini-app-tutorial), and [Build a Dual-Chain Mini App with Nimiq Pay](/mini-apps/tutorials/dual-chain-mini-app-tutorial).
 
 ## Quick Start Examples
 

--- a/content/mini-apps/development/_dir.yml
+++ b/content/mini-apps/development/_dir.yml
@@ -1,0 +1,4 @@
+title: Development
+icon: i-tabler:tools
+navigation:
+  order: 4

--- a/content/mini-apps/development/build-with-ai.md
+++ b/content/mini-apps/development/build-with-ai.md
@@ -4,7 +4,7 @@ description: Install an AI skill that gives your coding tool accurate context ab
 icon: i-tabler:sparkles
 navigation:
   title: Build with AI
-  order: 5
+  order: 2
 ---
 
 # Build with AI
@@ -55,8 +55,8 @@ The skill also includes local reference files with method signatures, supported 
 ## Reference
 
 - [Mini Apps Overview](/mini-apps/)
-- [Build Your First Mini App](/mini-apps/mini-app-tutorial)
-- [Using EVM Tokens](/mini-apps/evm-tokens)
+- [Build Your First Mini App](/mini-apps/tutorials/mini-app-tutorial)
+- [Using EVM Tokens](/mini-apps/features/evm-tokens)
 - [Nimiq Provider API](/mini-apps/api-reference/nimiq-provider)
 - [Ethereum Provider API](/mini-apps/api-reference/ethereum-provider)
 - [Agent Skills spec](https://skills.sh/)

--- a/content/mini-apps/development/load-local-mini-app.md
+++ b/content/mini-apps/development/load-local-mini-app.md
@@ -4,7 +4,7 @@ description: Load a local mini app into Nimiq Pay from your development machine
 icon: i-tabler:device-mobile-code
 navigation:
   title: Load a Local Mini App
-  order: 4
+  order: 1
 ---
 
 # Load a Local Mini App in Nimiq Pay
@@ -101,5 +101,5 @@ After switching to testnet, the empty-state home screen shows a **Get free NIM**
 
 ## Tutorials
 
-- Build a first mini app: [Mini app tutorial](/mini-apps/mini-app-tutorial)
-- Build a dual-chain mini app: [Build a Dual-Chain Mini App with Nimiq Pay](/mini-apps/dual-chain-mini-app-tutorial)
+- Build a first mini app: [Mini app tutorial](/mini-apps/tutorials/mini-app-tutorial)
+- Build a dual-chain mini app: [Build a Dual-Chain Mini App with Nimiq Pay](/mini-apps/tutorials/dual-chain-mini-app-tutorial)

--- a/content/mini-apps/faq.md
+++ b/content/mini-apps/faq.md
@@ -4,7 +4,7 @@ description: Answers to common questions about building mini apps for Nimiq Pay
 icon: i-tabler:help
 navigation:
   title: FAQ
-  order: 10
+  order: 7
 ---
 
 # Mini Apps FAQ
@@ -65,11 +65,11 @@ Yes. You can use any npm package, open-source template, or starter kit you like.
 
 ### Do I need to build a mini app from scratch, or can I reuse a project of mine?
 
-You don't have to start from scratch. If you already have a web app, you can adapt it. The main change is adding provider integration: connecting to the Nimiq or Ethereum provider and using it for at least one interaction. The `mini-apps` [AI skill](/mini-apps/build-with-ai) can audit your codebase, map your existing functionality to Nimiq Pay's providers, assess feasibility, and plan the conversion before making any changes. If you don't want to use AI, install the [Mini App SDK](https://www.npmjs.com/package/@nimiq/mini-app-sdk) for Nimiq provider access or call `window.ethereum` directly for Ethereum, and wire up the interactions that make sense for your app.
+You don't have to start from scratch. If you already have a web app, you can adapt it. The main change is adding provider integration: connecting to the Nimiq or Ethereum provider and using it for at least one interaction. The `mini-apps` [AI skill](/mini-apps/development/build-with-ai) can audit your codebase, map your existing functionality to Nimiq Pay's providers, assess feasibility, and plan the conversion before making any changes. If you don't want to use AI, install the [Mini App SDK](https://www.npmjs.com/package/@nimiq/mini-app-sdk) for Nimiq provider access or call `window.ethereum` directly for Ethereum, and wire up the interactions that make sense for your app.
 
 ### Do I need to use AI tools to build a mini app?
 
-No. AI tools are entirely optional. The [Build with AI](/mini-apps/build-with-ai) page documents a skill that gives AI coding tools accurate context about the framework, which helps them generate working code. If you prefer to build without AI, the tutorials and API reference have everything you need.
+No. AI tools are entirely optional. The [Build with AI](/mini-apps/development/build-with-ai) page documents a skill that gives AI coding tools accurate context about the framework, which helps them generate working code. If you prefer to build without AI, the tutorials and API reference have everything you need.
 
 ## Testing, security, and deployment
 

--- a/content/mini-apps/features/_dir.yml
+++ b/content/mini-apps/features/_dir.yml
@@ -1,0 +1,4 @@
+title: Features
+icon: i-tabler:components
+navigation:
+  order: 5

--- a/content/mini-apps/features/device-identifier.md
+++ b/content/mini-apps/features/device-identifier.md
@@ -4,7 +4,7 @@ description: Request a pseudonymous per-device handle from Nimiq Pay using reque
 icon: i-tabler:fingerprint
 navigation:
   title: Device Identifier
-  order: 9
+  order: 3
 ---
 
 # Device Identifier in Mini Apps

--- a/content/mini-apps/features/evm-tokens.md
+++ b/content/mini-apps/features/evm-tokens.md
@@ -4,7 +4,7 @@ description: Read balances and send ERC-20 tokens like USDT on Polygon through t
 icon: i-tabler:coins
 navigation:
   title: EVM Tokens
-  order: 7
+  order: 1
 ---
 
 # Using EVM Tokens in Mini Apps

--- a/content/mini-apps/features/localization.md
+++ b/content/mini-apps/features/localization.md
@@ -4,7 +4,7 @@ description: Match your mini app's language to the user's Nimiq Pay setting usin
 icon: i-tabler:language
 navigation:
   title: Localization
-  order: 8
+  order: 2
 ---
 
 # Localization in Mini Apps
@@ -76,7 +76,7 @@ const t = (nimiqPayLanguage in translations ? translations[nimiqPayLanguage] : n
 
 ## Framework examples
 
-The examples below show how to make the language value reactive in Vue, React, and Svelte. These are the frameworks covered in the [starter tutorials](/mini-apps/mini-app-tutorial). If you use a different framework, adapt the same pattern: read `window.nimiqPay?.language` once at init, apply the fallback chain, and use the result to index your translations.
+The examples below show how to make the language value reactive in Vue, React, and Svelte. These are the frameworks covered in the [starter tutorials](/mini-apps/tutorials/mini-app-tutorial). If you use a different framework, adapt the same pattern: read `window.nimiqPay?.language` once at init, apply the fallback chain, and use the result to index your translations.
 
 ::code-group
 

--- a/content/mini-apps/ideas.md
+++ b/content/mini-apps/ideas.md
@@ -4,7 +4,7 @@ description: A list of mini app ideas you can build with the Nimiq Mini Apps Fra
 icon: i-tabler:bulb
 navigation:
   title: Mini App Ideas
-  order: 6
+  order: 2
 ---
 
 # Mini App Ideas

--- a/content/mini-apps/index.md
+++ b/content/mini-apps/index.md
@@ -64,14 +64,14 @@ The framework supports two blockchain ecosystems:
 **Ethereum + Layer 2 networks** (EVM-compatible)
 
 - Ethereum Mainnet
-- [Polygon](/mini-apps/evm-tokens)
+- [Polygon](/mini-apps/features/evm-tokens)
 - Arbitrum One
 - Optimism
 - Base
 - BNB Smart Chain (formerly Binance Smart Chain)
 - Sepolia (testnet for developers)
 
-ERC-20 tokens on any listed chain — including USDT on Polygon — are accessible through `window.ethereum` with no additional setup. See [Using EVM Tokens in Mini Apps](/mini-apps/evm-tokens) for a worked example.
+ERC-20 tokens on any listed chain — including USDT on Polygon — are accessible through `window.ethereum` with no additional setup. See [Using EVM Tokens in Mini Apps](/mini-apps/features/evm-tokens) for a worked example.
 
 Any EVM-compatible chain supported by our RPC provider can be added; the list above reflects what we currently expose in Nimiq Pay. Additional EVM networks can be added over time via configuration updates.
 
@@ -83,7 +83,7 @@ Nimiq Pay exposes the user's selected language to mini apps via `window.nimiqPay
 const language = window.nimiqPay?.language // e.g. 'en'
 ```
 
-Use this instead of `navigator.language`, which returns the device locale and may not match the language the user selected in Nimiq Pay. For fallback patterns, translations setup, and framework examples, see [Localization in Mini Apps](/mini-apps/localization).
+Use this instead of `navigator.language`, which returns the device locale and may not match the language the user selected in Nimiq Pay. For fallback patterns, translations setup, and framework examples, see [Localization in Mini Apps](/mini-apps/features/localization).
 
 ## Device Identifier
 
@@ -95,7 +95,7 @@ import { requestDeviceIdentifier } from '@nimiq/mini-app-sdk'
 const id = await requestDeviceIdentifier({ reason: 'Leaderboard ranking' })
 ```
 
-The first call per origin prompts the user with the `reason` you provide; subsequent calls resolve silently. For privacy properties, error handling, and TypeScript types, see [Device Identifier in Mini Apps](/mini-apps/device-identifier).
+The first call per origin prompts the user with the `reason` you provide; subsequent calls resolve silently. For privacy properties, error handling, and TypeScript types, see [Device Identifier in Mini Apps](/mini-apps/features/device-identifier).
 
 ## Security and Permissions
 

--- a/content/mini-apps/tutorials/_dir.yml
+++ b/content/mini-apps/tutorials/_dir.yml
@@ -1,0 +1,4 @@
+title: Tutorials
+icon: i-tabler:school
+navigation:
+  order: 3

--- a/content/mini-apps/tutorials/dual-chain-mini-app-tutorial.md
+++ b/content/mini-apps/tutorials/dual-chain-mini-app-tutorial.md
@@ -3,7 +3,7 @@ description: Build a mini app that uses both Nimiq and Ethereum providers with u
 icon: i-tabler:arrows-split-2
 navigation:
   title: Build a Dual-Chain Mini App
-  order: 3
+  order: 2
 ---
 
 # Build a Dual-Chain Mini App with Nimiq Pay
@@ -339,7 +339,7 @@ const language = window.nimiqPay?.language
   || 'en'
 ```
 
-This reads the Nimiq Pay language first, falls back to the device locale, then to English. For a full translations setup, see [Localization in Mini Apps](/mini-apps/localization).
+This reads the Nimiq Pay language first, falls back to the device locale, then to English. For a full translations setup, see [Localization in Mini Apps](/mini-apps/features/localization).
 
 ## 6. Run the mini app
 

--- a/content/mini-apps/tutorials/mini-app-tutorial.md
+++ b/content/mini-apps/tutorials/mini-app-tutorial.md
@@ -3,7 +3,7 @@ description: Guide to setting up a Nimiq Pay minimal mini app dev
 icon: i-tabler:rocket
 navigation:
   title: Build Your First Mini App
-  order: 2
+  order: 1
 ---
 
 # Build Your First Nimiq Mini App
@@ -441,7 +441,7 @@ const language = window.nimiqPay?.language
   || 'en'
 ```
 
-This reads the Nimiq Pay language first, falls back to the device locale, then to English. For a full translations setup with framework examples, see [Localization in Mini Apps](/mini-apps/localization).
+This reads the Nimiq Pay language first, falls back to the device locale, then to English. For a full translations setup with framework examples, see [Localization in Mini Apps](/mini-apps/features/localization).
 
 ## 6. Run the mini app
 

--- a/skills/mini-apps/SKILL.md
+++ b/skills/mini-apps/SKILL.md
@@ -131,10 +131,10 @@ Do not do any of the following:
 Documentation:
 
 - [Mini Apps Overview](https://nimiq.dev/raw/mini-apps/index.md)
-- [Build Your First Mini App](https://nimiq.dev/raw/mini-apps/mini-app-tutorial.md)
-- [Build a Dual-Chain Mini App](https://nimiq.dev/raw/mini-apps/dual-chain-mini-app-tutorial.md)
-- [Load a Local Mini App](https://nimiq.dev/raw/mini-apps/load-local-mini-app.md)
-- [Using EVM Tokens in Mini Apps](https://nimiq.dev/raw/mini-apps/evm-tokens.md)
+- [Build Your First Mini App](https://nimiq.dev/raw/mini-apps/tutorials/mini-app-tutorial.md)
+- [Build a Dual-Chain Mini App](https://nimiq.dev/raw/mini-apps/tutorials/dual-chain-mini-app-tutorial.md)
+- [Load a Local Mini App](https://nimiq.dev/raw/mini-apps/development/load-local-mini-app.md)
+- [Using EVM Tokens in Mini Apps](https://nimiq.dev/raw/mini-apps/features/evm-tokens.md)
 - [Nimiq Provider API](https://nimiq.dev/raw/mini-apps/api-reference/nimiq-provider.md)
 - [Ethereum Provider API](https://nimiq.dev/raw/mini-apps/api-reference/ethereum-provider.md)
 

--- a/skills/mini-apps/references/chains-and-tokens.md
+++ b/skills/mini-apps/references/chains-and-tokens.md
@@ -26,4 +26,4 @@ Custom chains can be added using `wallet_addEthereumChain`.
 USDT and USDC use 6 decimals, not 18. Always use the token's actual `decimals` value.
 
 Full token list: https://raw.githubusercontent.com/Albermonte/evm-mini-wallet/refs/heads/main/src/utils/well-known-tokens.ts
-Full documentation: https://nimiq.dev/raw/mini-apps/evm-tokens.md
+Full documentation: https://nimiq.dev/raw/mini-apps/features/evm-tokens.md


### PR DESCRIPTION
Group the previously flat mini-apps pages into four sections to make the sidebar scannable. Update all internal links to the new paths.

Redirects for the old URLs are handled by IT outside this repo.